### PR TITLE
Support local proxy configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,6 +34,7 @@ type HeadersFunc func() http.Header
 
 var DefaultClient = &http.Client{
 	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 10 * time.Second,


### PR DESCRIPTION
Some, but not all, Convox CLI commands support local proxy configuration. I found proxy configuration worked for `convox logs`, but not `convox racks` or `convox apps` or `convox releases`.

Some spelunking through Go code (which I admittedly barely understand) showed [this line](https://github.com/convox/rack/blob/5223f1ec70045d6038ad130437af844207b6acfd/pkg/helpers/http.go#L27) as being a notable omission within `stdsdk`, which appears to be the source of the HTTP client for the `convox racks` call, at minimum.